### PR TITLE
Update examples.rst

### DIFF
--- a/hypothesis-python/docs/examples.rst
+++ b/hypothesis-python/docs/examples.rst
@@ -29,10 +29,8 @@ Suppose we've got the following type:
             return "Node(%r, %r)" % (self.label, self.value)
 
         def sorts_before(self, other):
-            if len(self.value) >= len(other.value):
-                return False
-            return other.value[:len(self.value)] == self.value
-
+            return len(self.value) < len(other.value)
+                and self.value == other.value[:len(self.value)]
 
 Each node is a label and a sequence of some data, and we have the relationship
 sorts_before meaning the data of the left is an initial segment of the right.


### PR DESCRIPTION
To me, the revision (untested) better expresses 'left (self) value is an initial segment of the right (other) value'.
